### PR TITLE
Determine event type at runtime (fixes #14)

### DIFF
--- a/src/Redbus/Redbus.Tests/EventBusTests.cs
+++ b/src/Redbus/Redbus.Tests/EventBusTests.cs
@@ -178,6 +178,18 @@ namespace Redbus.Tests
             Assert.IsTrue(thirdSubscriberHit); // Third subscriber will be hit, because we didn't throw.
         }
 
+        [TestMethod]
+        public void PublishCustomEventAsSubtype()
+        {
+            var eventBus = new EventBus();
+            bool subscriberHit = false;
+            eventBus.Subscribe<CustomTestEvent>(s => { subscriberHit = true; });
+
+            eventBus.Publish((EventBase)(new CustomTestEvent()));
+
+            Assert.IsTrue(subscriberHit);
+        }
+
         private void CustomTestEventMethodHandler(CustomTestEvent customTestEvent)
         {
             Assert.AreEqual("Custom Event", customTestEvent.Name);

--- a/src/Redbus/Redbus/EventBus.cs
+++ b/src/Redbus/Redbus/EventBus.cs
@@ -76,8 +76,8 @@ namespace Redbus
             var allSubscriptions = new List<ISubscription>();
             lock (SubscriptionsLock)
             {
-                if (_subscriptions.ContainsKey(typeof(TEventBase)))
-                    allSubscriptions = _subscriptions[typeof(TEventBase)].ToList();
+                if (_subscriptions.ContainsKey(eventItem.GetType()))
+                    allSubscriptions = _subscriptions[eventItem.GetType()].ToList();
             }
 
             for (var index = 0; index < allSubscriptions.Count; index++)


### PR DESCRIPTION
This PR changes the way RedBus determines which handler to call. It determines the type of the `eventItem` at runtime instead of compile-time.

**Caution:** This is a BC-break.